### PR TITLE
feat(*): Update default avatar images.

### DIFF
--- a/packages/core/src/avatars.json
+++ b/packages/core/src/avatars.json
@@ -4,5 +4,5 @@
 	"green": "https://cdn.discordapp.com/embed/avatars/2.png",
 	"yellow": "https://cdn.discordapp.com/embed/avatars/3.png",
 	"red": "https://cdn.discordapp.com/embed/avatars/4.png",
-	"pink": "https://cdn.discordapp.com/embed/avatars/5.png",
+	"pink": "https://cdn.discordapp.com/embed/avatars/5.png"
 }

--- a/packages/core/src/avatars.json
+++ b/packages/core/src/avatars.json
@@ -2,6 +2,7 @@
 	"blue": "https://cdn.discordapp.com/embed/avatars/0.png",
 	"gray": "https://cdn.discordapp.com/embed/avatars/1.png",
 	"green": "https://cdn.discordapp.com/embed/avatars/2.png",
-	"orange": "https://cdn.discordapp.com/embed/avatars/3.png",
-	"red": "https://cdn.discordapp.com/embed/avatars/4.png"
+	"yellow": "https://cdn.discordapp.com/embed/avatars/3.png",
+	"red": "https://cdn.discordapp.com/embed/avatars/4.png",
+	"pink": "https://cdn.discordapp.com/embed/avatars/5.png",
 }

--- a/packages/core/src/avatars.json
+++ b/packages/core/src/avatars.json
@@ -2,7 +2,7 @@
 	"blue": "https://cdn.discordapp.com/embed/avatars/0.png",
 	"gray": "https://cdn.discordapp.com/embed/avatars/1.png",
 	"green": "https://cdn.discordapp.com/embed/avatars/2.png",
-	"yellow": "https://cdn.discordapp.com/embed/avatars/3.png",
+	"orange": "https://cdn.discordapp.com/embed/avatars/3.png",
 	"red": "https://cdn.discordapp.com/embed/avatars/4.png",
 	"pink": "https://cdn.discordapp.com/embed/avatars/5.png"
 }


### PR DESCRIPTION
_(Moved from [vue-discord-message#10](https://github.com/Danktuary/vue-discord-message/pull/10))_

This PR updates the old default avatars to the new ones.

⚠️ This is a breaking change as it removes the `orange` avatar and replaces it with a `yellow` one.
ℹ️ This also adds a new `pink` avatar. Alternatively, this could be named `fuchsia`.